### PR TITLE
Cmake build instructions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ include_directories(src)
 # Find source files
 file(GLOB SOURCES src/*.c)
 
+# Find header files
+file(GLOB HEADERS src/*.h)
+
 # Create shared library
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package ( CURL )
 find_package ( JANSSON )
 
 # Install library
-install(TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})
+# install(TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})
 
 include_directories(${CURL_INCLUDE_DIRS})
 target_link_libraries (tgapi ${CURL_LIBRARIES})
@@ -30,7 +30,12 @@ target_link_libraries (tgapi ${JANSSON_LIBRARIES})
 
 
 message(STATUS "********************************************")
-message(STATUS "********** ${PROJECT_NAME} build options : **********")
+message(STATUS "********** ${PROJECT_NAME} build options : ***********")
 message(STATUS "CURL support:    ${CURL_FOUND}")
 message(STATUS "JANSSON support: ${JANSSON_FOUND}")
 message(STATUS "********************************************")
+
+install(TARGETS tgapi DESTINATION lib)
+install(FILES ${HEADERS} DESTINATION include)
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.6)
+project(tgapi)
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules )
+
+include(FindJansson)
+include(FindCURL)
+
+# Include header files
+include_directories(src)
+
+# Find source files
+file(GLOB SOURCES src/*.c)
+
+# Create shared library
+add_library(${PROJECT_NAME} SHARED ${SOURCES})
+
+find_package ( CURL )
+find_package ( JANSSON )
+
+# Install library
+install(TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})
+
+include_directories(${CURL_INCLUDE_DIRS})
+target_link_libraries (tgapi ${CURL_LIBRARIES})
+target_link_libraries (tgapi ${JANSSON_LIBRARIES})
+
+
+message(STATUS "********************************************")
+message(STATUS "********** ${PROJECT_NAME} build options : **********")
+message(STATUS "CURL support:    ${CURL_FOUND}")
+message(STATUS "JANSSON support: ${JANSSON_FOUND}")
+message(STATUS "********************************************")

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ apt install libcurl-dev libjansson-dev
 Afterwards to clone and compile execute the following commands:
 ```bash
 git clone https://github.com/77616c6964/tgc.git
-cd tgc/src
+cd tgc/
 make
 sudo make install
 ```
@@ -22,7 +22,7 @@ git clone https://github.com/77616c6964/tgc.git
 cd tgc
 mkdir build && cd build
 cmake install ..
-
+make
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ make
 sudo make install
 ```
 
+```
+If you're using cmake to build this project in a cross platform manner
+
+git clone https://github.com/77616c6964/tgc.git
+cd tgc
+mkdir build && cd build
+cmake install ..
+
+```
+
 
 ## Example
 

--- a/cmake/Modules/FindJansson.cmake
+++ b/cmake/Modules/FindJansson.cmake
@@ -1,0 +1,59 @@
+# - Try to find Jansson
+# Once done this will define
+#
+#  JANSSON_FOUND - system has Jansson
+#  JANSSON_INCLUDE_DIRS - the Jansson include directory
+#  JANSSON_LIBRARIES - Link these to use Jansson
+#
+#  Copyright (c) 2011 Lee Hambley <lee.hambley@gmail.com>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+if (JANSSON_LIBRARIES AND JANSSON_INCLUDE_DIRS)
+  # in cache already
+  set(JANSSON_FOUND TRUE)
+else (JANSSON_LIBRARIES AND JANSSON_INCLUDE_DIRS)
+  find_path(JANSSON_INCLUDE_DIR
+    NAMES
+      jansson.h
+    PATHS
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+  )
+
+find_library(JANSSON_LIBRARY
+    NAMES
+      jansson
+    PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+set(JANSSON_INCLUDE_DIRS
+  ${JANSSON_INCLUDE_DIR}
+  )
+
+if (JANSSON_LIBRARY)
+  set(JANSSON_LIBRARIES
+    ${JANSSON_LIBRARIES}
+    ${JANSSON_LIBRARY}
+    )
+endif (JANSSON_LIBRARY)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Jansson DEFAULT_MSG
+    JANSSON_LIBRARIES JANSSON_INCLUDE_DIRS)
+
+  # show the JANSSON_INCLUDE_DIRS and JANSSON_LIBRARIES variables only in the advanced view
+  mark_as_advanced(JANSSON_INCLUDE_DIRS JANSSON_LIBRARIES)
+
+endif (JANSSON_LIBRARIES AND JANSSON_INCLUDE_DIRS)
+
+


### PR DESCRIPTION
Not sure if you'd want this, but I thought this should be included in a separate pull request.  This is the cmake file for building tgc using cmake.  It -seems- to work for me.

As you can build its own directory, it should be able to co-exist beside your current makefile style build environment.   My cmake option doesn't build docs yet (I'll look into that eventually).

Thanks for your patience so far.